### PR TITLE
Execute commands using default shell

### DIFF
--- a/butler-base.sh
+++ b/butler-base.sh
@@ -81,7 +81,8 @@ execute() {
   local args=$@
   if can_continue "$name" "$command"; then
     echo "Executing $name: $command"
-    bash -c "$command" -- $args
+    local shell=${BUTLER_SHELL:-${SHELL:-bash}}
+    $shell -c "$command" -- $args
   fi
 }
 

--- a/butlerfile
+++ b/butlerfile
@@ -1,2 +1,1 @@
 test: ./test.sh
-tests: echo 'totally not tests, lolololol'


### PR DESCRIPTION
Falls back gracefully on `bash` and if you want you can set `$BUTLER_SHELL` to make butler to use a different shell other than your default or bash.

Currently doesn't get access to your customisations in your rcfile so some path settings might not be correct.
