### PR TITLE
Switch execution env to bash

### DIFF
--- a/butler
+++ b/butler
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 #
 # Butler
 #

--- a/butler-base.sh
+++ b/butler-base.sh
@@ -5,6 +5,12 @@
 # The API for Butler.
 # Let the Butler do it.
 
+if [[ "$OSTYPE" == *darwin* ]]; then
+  SHA_CMD="gsha256sum"
+else
+  SHA_CMD="sha256sum"
+fi
+
 usage() {
   echo "usage:"
   echo "  butler [COMMAND]    # Run a command defined in your butlerfile"
@@ -35,7 +41,7 @@ complete_command() {
 }
 
 hash_this() {
-  echo "$@" | gsha256sum | sed 's/  -$//'
+  echo "$@" | $SHA_CMD | sed 's/  -$//'
 }
 
 record_hash() {

--- a/butler-base.sh
+++ b/butler-base.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 #
 # Butler-base
 #

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 
 run_tests() {
   for t in tests/*_test.sh; do


### PR DESCRIPTION
Debian and Ubuntu have `sh` aliased to `dash`. Full details of the problem this causes are in [issue#7](https://github.com/michaeldfallen/butler/issues/7) reported by @Boldewyn.

To fix this we've switched to executing using bash.
